### PR TITLE
add transpose formatoption

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@ v1.2.1
 ======
 Added
 -----
+* all plotmethods now have a ``transpose`` formatoption that can be used if the
+  order of dimensions in the data is ``(x, y)`` rather than ``(y, x)``
 * the `transform` and `projection` formatoptions now automatically decode the
   ``'grid_mappings'`` attribute following the `CF-conventions <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#appendix-grid-mappings>`__,
   see `#5 <https://github.com/psyplot/psy-maps/pull/5>`__)

--- a/psy_maps/plugin.py
+++ b/psy_maps/plugin.py
@@ -152,6 +152,8 @@ rcParams = RcParams(defaultParams={
     # --------------------- Default formatoptions -----------------------------
     # -------------------------------------------------------------------------
     # MapBase
+    'plotter.maps.transpose': [
+        False, validate_bool, "Transpose the input data before plotting"],
     'plotter.maps.lonlatbox': [
         None, validate_lonlatbox,
         'fmt key to define the longitude latitude box of the data'],


### PR DESCRIPTION
This PR adds a `transpose` formatoption in case the order of dimensions in the data is `(x, y)` instead of `(y, x)`.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
