### PR TITLE
set clon and clat to 0 only for global files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Changed
   see `#4 <https://github.com/psyplot/psy-maps/pull/4>`__
 * the default values for the `transform` and `projection` formatoptions are now
   ``'cf'`` (see `#5 <https://github.com/psyplot/psy-maps/pull/5>`__)
+* ``clat`` now always takes the mean latitude of the data if the formatoption
+  value is None (see `#8 <https://github.com/psyplot/psy-maps/pull/8>`__)
+* ``clon`` now takes the mean latitude of the data if the formatoption
+  value is None and the data does not span the entire world
+  (see `#8 <https://github.com/psyplot/psy-maps/pull/8>`__)
 
 v1.2.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,10 +17,10 @@ Changed
 * the default values for the `transform` and `projection` formatoptions are now
   ``'cf'`` (see `#5 <https://github.com/psyplot/psy-maps/pull/5>`__)
 * ``clat`` now always takes the mean latitude of the data if the formatoption
-  value is None (see `#8 <https://github.com/psyplot/psy-maps/pull/8>`__)
-* ``clon`` now takes the mean latitude of the data if the formatoption
-  value is None and the data does not span the entire world
-  (see `#8 <https://github.com/psyplot/psy-maps/pull/8>`__)
+  value is None and the data does not span the entire latitudinal range. At the
+  same time, ``clon`` now takes the mean longitude of the data if the
+  formatoption value is None and the data does not span the entire longitudinal
+  range (see `#8 <https://github.com/psyplot/psy-maps/pull/8>`__)
 
 v1.2.0
 ======

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -634,7 +634,11 @@ class CenterLat(BoxBase):
             else:
                 self.clat = value
         if value is None:
-            self.clat = self.lat_mean
+            latmin, latmax = self.lonlatbox.lonlatbox[2:]
+            if latmax - latmin > 170:
+                self.clat = 0
+            else:
+                self.clat = self.lat_mean
 
 
 @docstrings.get_sectionsf('LonLatBox')

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -593,10 +593,12 @@ class CenterLon(BoxBase):
                     value = None
             else:
                 self.clon = value
-        if value is None and self.lonlatbox.value is not None:
-            self.clon = self.lon_mean
-        elif value is None:
-            self.clon = 0.0
+        if value is None:
+            lonmin, lonmax = self.lonlatbox.lonlatbox[:2]
+            if lonmax - lonmin > 350:
+                self.clon = 0.0
+            else:
+                self.clon = self.lon_mean
 
 
 class CenterLat(BoxBase):
@@ -631,10 +633,8 @@ class CenterLat(BoxBase):
                     value = None
             else:
                 self.clat = value
-        if value is None and self.lonlatbox.value is not None:
+        if value is None:
             self.clat = self.lat_mean
-        elif value is None:
-            self.clat = 0.0
 
 
 @docstrings.get_sectionsf('LonLatBox')

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -437,8 +437,9 @@ class TestProjectedLonlatbox(unittest.TestCase):
         sp = psy.plot.mapplot(os.path.join(bt.test_dir, 'Stockholm.nc'),
                               name='Population', transform='moll')
         ax = sp.plotters[0].ax
-        self.assertEqual(np.round(ax.get_extent(), 2).tolist(),
-                         [17.66, 18.39, 59.1, 59.59])
+        self.assertEqual(
+            np.round(ax.get_extent(ccrs.PlateCarree()), 2).tolist(),
+            [17.66, 18.39, 59.1, 59.59])
         sp.update(lonlatbox=[17.8, 18.2, 59.2, 59.4])
         self.assertEqual(
             np.round(ax.get_extent(ccrs.PlateCarree()), 2).tolist(),


### PR DESCRIPTION
if clon is None and clat is None

 Closes #7 

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes

ping @Casthardi, this solves the wrong focus of the orthographic plots of regional files (see #7).