### PR TITLE
use ccrs.PlateCarree if standard_name is longitude

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Added
   order of dimensions in the data is ``(x, y)`` rather than ``(y, x)``
 * the `transform` and `projection` formatoptions now automatically decode the
   ``'grid_mappings'`` attribute following the `CF-conventions <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#appendix-grid-mappings>`__,
-  see `#5 <https://github.com/psyplot/psy-maps/pull/5>`__)
+  see `#5 <https://github.com/psyplot/psy-maps/pull/5>`__,
+  `#10 <https://github.com/psyplot/psy-maps/pull/10>`__)
 * the ``projection`` and ``transform`` formatoptions now also support a `rotated`
   value to use a rotated pole projection
 

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -583,12 +583,12 @@ class CenterLon(BoxBase):
     dependencies = ['lonlatbox']
 
     def update(self, value):
-        self.lon_mean = np.mean(self.lonlatbox.lonlatbox[:2])
+        self.lon_mean = float(np.mean(self.lonlatbox.lonlatbox[:2]))
         if value is not None:
             if isinstance(value, six.string_types):
                 box = self.lola_from_pattern(value)
                 if box is not None:
-                    self.clon = np.mean(box[:2])
+                    self.clon = float(np.mean(box[:2]))
                 else:
                     value = None
             else:
@@ -623,12 +623,12 @@ class CenterLat(BoxBase):
     dependencies = ['lonlatbox']
 
     def update(self, value):
-        self.lat_mean = np.mean(self.lonlatbox.lonlatbox[2:])
+        self.lat_mean = float(np.mean(self.lonlatbox.lonlatbox[2:]))
         if value is not None:
             if isinstance(value, six.string_types):
                 box = self.lola_from_pattern(value)
                 if box is not None:
-                    self.clat = np.mean(box[2:])
+                    self.clat = float(np.mean(box[2:]))
                 else:
                     value = None
             else:
@@ -1047,6 +1047,14 @@ class Transform(ProjectionBase):
     name = 'Coordinate system of the data'
 
     connections = ['plot', 'vplot']
+
+    @property
+    def cf_projection(self):
+        data = next(self.iter_data)
+        xcoord = data.psy.get_coord('x')
+        if xcoord.attrs.get('standard_name') == 'longitude':
+            return ccrs.PlateCarree()
+        return super().cf_projection
 
     def update(self, value):
         if value == 'cf':

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -77,3 +77,15 @@ def test_clat_centering(open_grid_ds, grid, clat):
     with grid_ds.psy.plot.mapplot(projection='ortho') as sp:
         plotter = sp.plotters[0]
         assert plotter.clat.clat == pytest.approx(clat, abs=1)
+
+
+def test_rotated_pole_transform(open_grid_ds):
+    """Test if the lon coordinate is correctly interpreted as PlateCarree
+
+    See https://github.com/psyplot/psy-maps/issues/9"""
+    grid_ds = open_grid_ds('rotated_latitude_longitude')
+    with grid_ds.psy.plot.mapplot(decoder=dict(x={'lon'}, y={'lat'})) as sp:
+        plotter = sp.plotters[0]
+        assert isinstance(plotter.transform.projection, ccrs.PlateCarree)
+        assert isinstance(plotter.ax.projection, ccrs.RotatedPole)
+


### PR DESCRIPTION
for cf decoded projections of the transform formatoption, see  https://github.com/psyplot/psy-view/issues/17

Closes #9
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
