### PR TITLE
copy cartopy strategy at the boundary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Added
 
 Changed
 -------
+* A bug has been fixed visualizing unstructured grid cells at the poles (see
+  `#23 <https://github.com/psyplot/psy-maps/pull/23>`__)
 * the ``lsm`` formatoptions value is now a dictionary. Old values, such as
   the string ``'10m'`` or ``['10m', 1.0]`` are still valid and will be converted
   to a dictionary (see `#17 <https://github.com/psyplot/psy-maps/pull/17>`__).

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -1383,6 +1383,19 @@ class IconFieldPlotterTest(FieldPlotterTest):
                                  msg=msg % ('latitude', 'maximum'))
         self.compare_figures(next(iter(args), self.get_ref_file('lonlatbox')))
 
+    def ref_pole(self):
+        """Test whether the grid cells are correctly displayed at the pole"""
+        sp = self.plot(projection="northpole", lonlatbox=[-180, 180, 80, 90],
+                       cmap='viridis', datagrid='r-')
+        sp.export(os.path.join(bt.ref_dir, self.get_ref_file('pole')))
+        sp.close(True, True, True)
+
+    def test_pole(self):
+        """Test whether the grid cells are correctly displayed at the pole"""
+        self.update(projection="northpole", lonlatbox=[-180, 180, 80, 90],
+                    cmap='viridis', datagrid='r-')
+        self.compare_figures(self.get_ref_file('pole'))
+
 
 class IconEdgeFieldPlotterTest(FieldPlotterTest):
     """Test :class:`psyplot.plotter.maps.FieldPlotter` class for icon grid"""

--- a/tests/test_plotters.py
+++ b/tests/test_plotters.py
@@ -1385,8 +1385,9 @@ class IconFieldPlotterTest(FieldPlotterTest):
 
     def ref_pole(self):
         """Test whether the grid cells are correctly displayed at the pole"""
-        sp = self.plot(projection="northpole", lonlatbox=[-180, 180, 80, 90],
-                       cmap='viridis', datagrid='r-')
+        sp = self.plot()
+        sp.update(projection="northpole", lonlatbox=[-180, 180, 80, 90],
+                  cmap='viridis', datagrid='r-')
         sp.export(os.path.join(bt.ref_dir, self.get_ref_file('pole')))
         sp.close(True, True, True)
 


### PR DESCRIPTION
this commit copies the methodolgy by cartopys _pcolormesh_patched method to identy the grid cell at the boundaries

Closes #22

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
