### PR TITLE
Remove deprecated matplotlib method from library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+v1.3.4
+======
+
+Fixed
+-----
+- minor fix of calling a deprecated function in matplotlib
+  (use `os.path.exists` instead of `matplotlib.rcsetup.validate_path_exists`)
+
+
 v1.3.3
 ======
 

--- a/psy_maps/plugin.py
+++ b/psy_maps/plugin.py
@@ -4,7 +4,7 @@ This module defines the rcParams for the psy-simple plugin"""
 import six
 import yaml
 from psyplot.config.rcsetup import RcParams
-from matplotlib.rcsetup import validate_path_exists
+from os.path import exists as validate_path_exists
 from psy_simple.plugin import (
     try_and_error, validate_none, validate_str, validate_float,
     validate_bool_maybe_none, validate_fontsize,


### PR DESCRIPTION
According to [matplotlib](https://matplotlib.org/3.2.1/api/api_changes.html) the method `validate_path_exists` is deprecated and should be replaced by `os.path.exists`

 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
