### PR TITLE
make false_easting and false_northing optional

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ after_test:
 deploy_script:
     - cmd: "
         IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (
-            deploy-conda-recipe -l %APPVEYOR_REPO_BRANCH% -py %PYTHON_VERSION% ci/conda-recipe
+            deploy-conda-recipe -l %APPVEYOR_REPO_BRANCH:/=-% -py %PYTHON_VERSION% ci/conda-recipe
         ) ELSE (
             deploy-conda-recipe -py %PYTHON_VERSION% ci/conda-recipe
         )"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.24
+  psyplot: psyplot/psyplot-ci-orb@1.5.27
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,21 @@
+v1.4.1
+======
+Fix projection issues
+
+Fixed
+-----
+- ``false_easting`` and ``false_northing`` are now expected to be optional
+  arguments for most projections (see
+  `#41 <https://github.com/psyplot/psy-maps/pull/41>`__)
+
+Changed
+-------
+- we now use the ``convert_coordinate`` method that has been introduced in
+  `psyplot/psyplot#39 <https://github.com/psyplot/psyplot/pull/39>`__ and
+  `psyplot/psy-simple#30 <https://github.com/psyplot/psy-simple/pull/30>`__.
+  See `#41 <https://github.com/psyplot/psy-maps/pull/41>`__
+
+
 v1.4.0
 ======
 Compatibility fixes and LGPL license

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -319,9 +319,9 @@ class ProjectionBase(Formatoption):
             iter(kwargs['standard_parallels'])
         except TypeError:
             kwargs['standard_parallels'] = [kwargs['standard_parallels']]
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.AlbersEqualArea(**kwargs)
 
@@ -330,9 +330,9 @@ class ProjectionBase(Formatoption):
             central_longitude=crs.longitude_of_projection_origin,
             central_latitude=crs.latitude_of_projection_origin,
             )
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.AzimuthalEquidistant(**kwargs)
 
@@ -342,9 +342,9 @@ class ProjectionBase(Formatoption):
             satellite_height=crs.perspective_point_height,
             sweep_axis=crs.sweep_angle_axis,
             )
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.Geostationary(**kwargs)
 
@@ -353,9 +353,9 @@ class ProjectionBase(Formatoption):
             central_longitude=crs.longitude_of_projection_origin,
             central_latitude=crs.latitude_of_projection_origin,
             )
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.LambertAzimuthalEqualArea(**kwargs)
 
@@ -390,9 +390,9 @@ class ProjectionBase(Formatoption):
             )
         if hasattr(crs, 'scale_factor_at_projection_origin'):
             kwargs['scale_factor'] = crs.scale_factor_at_projection_origin
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.Mercator(**kwargs)
 
@@ -427,9 +427,9 @@ class ProjectionBase(Formatoption):
             kwargs = dict(
                 central_longitude=crs.longitude_of_central_meridian,
                 )
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.Sinusoidal(**kwargs)
 
@@ -451,9 +451,9 @@ class ProjectionBase(Formatoption):
             central_latitude=crs.latitude_of_projection_origin,
             scale_factor=crs.scale_factor_at_central_meridian,
             )
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.TransverseMercator(**kwargs)
 

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -2047,10 +2047,6 @@ class MapPlotter(psyps.Base2D):
     """Base plotter for visualizing data on a map
     """
 
-    #: Boolean that is True if coordinates with units in radian should be
-    #: converted to degrees
-    convert_radian = True
-
     _rcparams_string = ['plotter.maps.']
 
     background = MapBackground('background')
@@ -2092,6 +2088,37 @@ class MapPlotter(psyps.Base2D):
     @ax.setter
     def ax(self, value):
         self._ax = value
+
+    @docstrings.dedent
+    def convert_coordinate(self, coord, *variables):
+        """Convert a coordinate from radian to degree.
+
+        This method checks if the coordinate or one of the given variables has
+        units in radian. If yes, the given `coord` is converted to degree.
+
+        Parameters
+        ----------
+        %(Formatoption.convert_coordinate.parameters)s
+
+        Returns
+        -------
+        %(Formatoption.convert_coordinate.returns)s
+        """
+
+        def in_rad(var):
+            return var.attrs.get('units', '').startswith('radian')
+
+        def in_km(var):
+            return var.attrs.get('units', '') == "km"
+
+        if any(map(in_rad, chain([coord], variables))):
+            coord = coord.copy(data=coord * 180. / np.pi)
+            coord.attrs["units"] = "degrees"
+        elif any(map(in_km, chain([coord], variables))):
+            coord = coord.copy(data=coord * 1000)
+            coord.attrs["units"] = "m"
+
+        return coord
 
 
 class FieldPlotter(psyps.Simple2DBase, MapPlotter, psyps.BasePlotter):

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -1121,16 +1121,7 @@ class Transform(ProjectionBase):
         xcoord = data.psy.get_coord('x')
         if xcoord.attrs.get('standard_name') == 'longitude':
             return ccrs.PlateCarree()
-        crs = super().cf_projection
-        # eventually transform to meters if in kilometers
-        self.transform_to_meter(crs)
-        return crs
-
-    def set_projection(self, value, *args, **kwargs):
-        crs = super().set_projection(value, *args, **kwargs)
-        # eventually transform to meters if in kilometers
-        self.transform_to_meter(crs)
-        return crs
+        return super().cf_projection
 
     def update(self, value):
         if value == 'cf':
@@ -1146,45 +1137,6 @@ class Transform(ProjectionBase):
                 getattr(self, key)._kwargs['transform'] = self.projection
             except AttributeError:
                 pass
-
-    def transform_to_meter(self, crs: ccrs.CRS):
-        """Transform x- and y-coordinates to meter.
-
-        This method checks the plotted data and transforms the coordinates to
-        meter if they are in units of kilometer (i.e. ``km``).
-
-        Notes
-        -----
-        The returned data array is a copy of the original `da` if and only if
-        the coordinates have been transformed
-        """
-        in_meters = (
-            ccrs.AlbersEqualArea,
-            ccrs.AzimuthalEquidistant,
-            ccrs.Geostationary,
-            ccrs.LambertAzimuthalEqualArea,
-            ccrs.LambertConformal,
-            ccrs.LambertCylindrical,
-            ccrs.Mercator,
-            ccrs.Orthographic,
-            ccrs.SouthPolarStereo,
-            ccrs.NorthPolarStereo,
-            ccrs.Sinusoidal,
-            ccrs.Stereographic,
-            ccrs.TransverseMercator,
-        )
-        if isinstance(crs, in_meters):
-            for i, da in enumerate(self.iter_data):
-                xcoord = da.psy.get_coord("x")
-                if xcoord.attrs.get("units") == "km":
-                    da = da.psy.copy()
-                    da[xcoord.name] = xcoord * 1000.
-                    self.set_data(da, i)
-                ycoord = da.psy.get_coord("y")
-                if ycoord.attrs.get("units") == "km":
-                    da = da.psy.copy()
-                    da[ycoord.name] = ycoord * 1000.
-                    self.set_data(da, i)
 
 
 class LSM(Formatoption):

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -1121,7 +1121,16 @@ class Transform(ProjectionBase):
         xcoord = data.psy.get_coord('x')
         if xcoord.attrs.get('standard_name') == 'longitude':
             return ccrs.PlateCarree()
-        return super().cf_projection
+        crs = super().cf_projection
+        # eventually transform to meters if in kilometers
+        self.transform_to_meter(crs)
+        return crs
+
+    def set_projection(self, value, *args, **kwargs):
+        crs = super().set_projection(value, *args, **kwargs)
+        # eventually transform to meters if in kilometers
+        self.transform_to_meter(crs)
+        return crs
 
     def update(self, value):
         if value == 'cf':
@@ -1137,6 +1146,45 @@ class Transform(ProjectionBase):
                 getattr(self, key)._kwargs['transform'] = self.projection
             except AttributeError:
                 pass
+
+    def transform_to_meter(self, crs: ccrs.CRS):
+        """Transform x- and y-coordinates to meter.
+
+        This method checks the plotted data and transforms the coordinates to
+        meter if they are in units of kilometer (i.e. ``km``).
+
+        Notes
+        -----
+        The returned data array is a copy of the original `da` if and only if
+        the coordinates have been transformed
+        """
+        in_meters = (
+            ccrs.AlbersEqualArea,
+            ccrs.AzimuthalEquidistant,
+            ccrs.Geostationary,
+            ccrs.LambertAzimuthalEqualArea,
+            ccrs.LambertConformal,
+            ccrs.LambertCylindrical,
+            ccrs.Mercator,
+            ccrs.Orthographic,
+            ccrs.SouthPolarStereo,
+            ccrs.NorthPolarStereo,
+            ccrs.Sinusoidal,
+            ccrs.Stereographic,
+            ccrs.TransverseMercator,
+        )
+        if isinstance(crs, in_meters):
+            for i, da in enumerate(self.iter_data):
+                xcoord = da.psy.get_coord("x")
+                if xcoord.attrs.get("units") == "km":
+                    da = da.psy.copy()
+                    da[xcoord.name] = xcoord * 1000.
+                    self.set_data(da, i)
+                ycoord = da.psy.get_coord("y")
+                if ycoord.attrs.get("units") == "km":
+                    da = da.psy.copy()
+                    da[ycoord.name] = ycoord * 1000.
+                    self.set_data(da, i)
 
 
 class LSM(Formatoption):

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -369,9 +369,9 @@ class ProjectionBase(Formatoption):
             iter(kwargs['standard_parallels'])
         except TypeError:
             kwargs['standard_parallels'] = [kwargs['standard_parallels']]
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.LambertConformal(**kwargs)
 
@@ -439,9 +439,9 @@ class ProjectionBase(Formatoption):
             central_longitude=crs.longitude_of_projection_origin,
             scale_factor=crs.scale_factor_at_projection_origin
             )
-        if getattr(crs, 'false_easting'):
+        if getattr(crs, 'false_easting', None):
             kwargs['false_easting'] = crs.false_easting
-        if getattr(crs, 'false_northing'):
+        if getattr(crs, 'false_northing', None):
             kwargs['false_northing'] = crs.false_northing
         return ccrs.Stereographic(**kwargs)
 

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -123,3 +123,36 @@ def test_rotated_pole_extent(open_grid_ds):
         assert isinstance(plotter.ax.projection, ccrs.RotatedPole)
         lonmin, lonmax = plotter.ax.get_extent()[:2]
         assert lonmax - lonmin < 200
+
+
+def test_false_easting(open_grid_ds, grid, grid_projection):
+    grid_ds = open_grid_ds(grid)
+    grid_var = grid_ds["Band1"].grid_mapping
+    if "false_easting" not in grid_ds[grid_var].attrs:
+        pytest.skip(f"No false_easting parameter for {grid_var} grid.")
+        return
+    del grid_ds[grid_var].attrs["false_easting"]
+    with grid_ds.psy.plot.mapplot() as sp:
+        assert len(sp) == 1
+        plotter = sp.plotters[0]
+        assert isinstance(plotter.transform.projection, grid_projection)
+        assert plotter.plot._kwargs.get('transform') is \
+            plotter.transform.projection
+        assert isinstance(plotter.projection.projection, grid_projection)
+
+
+def test_false_northing(open_grid_ds, grid, grid_projection):
+    grid_ds = open_grid_ds(grid)
+    grid_var = grid_ds["Band1"].grid_mapping
+    if "false_northing" not in grid_ds[grid_var].attrs:
+        pytest.skip(f"No false_northing parameter for {grid_var} grid.")
+        return
+    del grid_ds[grid_var].attrs["false_northing"]
+    with grid_ds.psy.plot.mapplot() as sp:
+        assert len(sp) == 1
+        plotter = sp.plotters[0]
+        assert isinstance(plotter.transform.projection, grid_projection)
+        assert plotter.plot._kwargs.get('transform') is \
+            plotter.transform.projection
+        assert isinstance(plotter.projection.projection, grid_projection)
+


### PR DESCRIPTION
this second part fixes the visualization of the lambert conformal grid in psyplot/psyplot#38. The current implementation assumed the `false_easting` and `false_northing` attributes to be mandatory, although they should be optional.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
