### PR TITLE
Compatibility fixes for psy-simple v1.4.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ after_test:
 deploy_script:
     - cmd: "
         IF NOT DEFINED APPVEYOR_REPO_TAG_NAME (
-            deploy-conda-recipe -l %APPVEYOR_REPO_BRANCH% -py %PYTHON_VERSION% ci/conda-recipe
+            deploy-conda-recipe -l %APPVEYOR_REPO_BRANCH:/=-% -py %PYTHON_VERSION% ci/conda-recipe
         ) ELSE (
             deploy-conda-recipe -py %PYTHON_VERSION% ci/conda-recipe
         )"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.27
+  psyplot: psyplot/psyplot-ci-orb@1.5.28
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.28
+  psyplot: psyplot/psyplot-ci-orb@1.5.29
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.24
+  psyplot: psyplot/psyplot-ci-orb@1.5.27
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.29
+  psyplot: psyplot/psyplot-ci-orb@1.5.31
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,21 @@
+v1.4.1
+======
+Fix projection issues
+
+Fixed
+-----
+- ``false_easting`` and ``false_northing`` are now expected to be optional
+  arguments for most projections (see
+  `#41 <https://github.com/psyplot/psy-maps/pull/41>`__)
+
+Changed
+-------
+- we now use the ``convert_coordinate`` method that has been introduced in
+  `psyplot/psyplot#39 <https://github.com/psyplot/psyplot/pull/39>`__ and
+  `psyplot/psy-simple#30 <https://github.com/psyplot/psy-simple/pull/30>`__.
+  See `#41 <https://github.com/psyplot/psy-maps/pull/41>`__
+
+
 v1.4.0
 ======
 Compatibility fixes and LGPL license

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,7 @@
 name: psyplot_docs
 channels:
     - local
+    - psyplot/label/__CURRENTBRANCH__
     - psyplot/label/master
     - conda-forge
 dependencies:

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -123,3 +123,36 @@ def test_rotated_pole_extent(open_grid_ds):
         assert isinstance(plotter.ax.projection, ccrs.RotatedPole)
         lonmin, lonmax = plotter.ax.get_extent()[:2]
         assert lonmax - lonmin < 200
+
+
+def test_false_easting(open_grid_ds, grid, grid_projection):
+    grid_ds = open_grid_ds(grid)
+    grid_var = grid_ds["Band1"].grid_mapping
+    if "false_easting" not in grid_ds[grid_var].attrs:
+        pytest.skip(f"No false_easting parameter for {grid_var} grid.")
+        return
+    del grid_ds[grid_var].attrs["false_easting"]
+    with grid_ds.psy.plot.mapplot() as sp:
+        assert len(sp) == 1
+        plotter = sp.plotters[0]
+        assert isinstance(plotter.transform.projection, grid_projection)
+        assert plotter.plot._kwargs.get('transform') is \
+            plotter.transform.projection
+        assert isinstance(plotter.projection.projection, grid_projection)
+
+
+def test_false_northing(open_grid_ds, grid, grid_projection):
+    grid_ds = open_grid_ds(grid)
+    grid_var = grid_ds["Band1"].grid_mapping
+    if "false_northing" not in grid_ds[grid_var].attrs:
+        pytest.skip(f"No false_northing parameter for {grid_var} grid.")
+        return
+    del grid_ds[grid_var].attrs["false_northing"]
+    with grid_ds.psy.plot.mapplot() as sp:
+        assert len(sp) == 1
+        plotter = sp.plotters[0]
+        assert isinstance(plotter.transform.projection, grid_projection)
+        assert plotter.plot._kwargs.get('transform') is \
+            plotter.transform.projection
+        assert isinstance(plotter.projection.projection, grid_projection)
+


### PR DESCRIPTION
This PR implements the compatibility for matplotlib 3.5 and the convert_coordinate API implemented in psyplot/psyplot#46 and psyplot/psy-simple#32

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
