### PR TITLE
add target_extent for mapdensity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  psyplot: psyplot/psyplot-ci-orb@1.5.31
+  psyplot: psyplot/psyplot-ci-orb@1.5.32
   mattermost-plugin-notify: nathanaelhoun/mattermost-plugin-notify@1.2.0
 
 executors:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+V1.4.2
+======
+Fix mapvector issue
+
+Fixed
+-----
+- This PR fixes an issue that arises when using ``density`` together with
+  ``lonlatbox``, see `#43 <https://github.com/psyplot/psy-maps/issues/43>`__
+  and `#44 <https://github.com/psyplot/psy-maps/pull/44>`__
+
 v1.4.1
 ======
 Fix projection issues

--- a/psy_maps/plotters.py
+++ b/psy_maps/plotters.py
@@ -989,7 +989,7 @@ class MapExtent(BoxBase):
                 value = self.lola_from_pattern(value)
         elif value is None:
             # use autoscale
-            # self.ax.autoscale()
+            self.ax.autoscale()
             return
         else:
             value = list(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@
 #
 # You should have received a copy of the GNU LGPL-3.0 license
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import pytest
+import os.path as osp
 
 try:
     # make sure we import QtWebEngineWidgets at the start
@@ -40,3 +42,8 @@ def pytest_configure(config):
     if config.getoption('ref'):
         import unittest
         unittest.TestLoader.testMethodPrefix = 'ref'
+
+
+@pytest.fixture
+def regular_test_file():
+    return osp.join(osp.dirname(__file__), "test-t2m-u-v.nc")

--- a/tests/test_plotters_vectorplotter.py
+++ b/tests/test_plotters_vectorplotter.py
@@ -175,5 +175,20 @@ class VectorPlotterTest2D(bt.TestBase2D, VectorPlotterTest):
     var = ['u_2d', 'v_2d']
 
 
+def test_density_with_lonlatbox(regular_test_file):
+    """Test that the lonlatbox still works with density.
+
+    see https://github.com/psyplot/psy-maps/issues/43
+    """
+    sp = psy.plot.mapvector(
+        regular_test_file, name=[["u", "v"]], density=0.5, lonlatbox="Europe"
+    )
+    ax = sp.plotters[0].ax
+    xmin, xmax, ymin, ymax = ax.get_extent()
+    assert xmax - xmin < 180
+    assert ymax - ymin < 90
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements a fix for #43 (ping @victoria-cherkas). The quiver method of cartopy takes a`target_extent` keyword that defaults to the map projection limits (which is by default global in the beginning). 

```
        target_extent: 4-tuple
            If given, specifies the extent in the target CRS that the
            regular grid defined by *regrid_shape* will have. Defaults
            to the current extent of the map projection.
```

We did not specify this, which it is why the `quiver` collection has a global `datalimit`. This PR should fix this

closes #43

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Fully documented, including `CHANGELOG.rst` for all changes
